### PR TITLE
Add dev setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Or with [`just`](https://github.com/casey/just), e.g. `just example snake -r`.
 - install [just](https://github.com/casey/just?tab=readme-ov-file#installation)
 - install [nickel](https://github.com/tweag/nickel?tab=readme-ov-file#run) for modifying CI configuration (`nickel` must be in your PATH)
 - install [File Watcher](https://marketplace.visualstudio.com/items?itemName=appulate.filewatcher) for automatically syncing nickels
+- run `./scripts/dev_setup.sh` to initialize submodules, install tools and system dependencies, and fetch cargo dependencies
 
 ## license
 All code in this repository is dual-licensed under either:

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root and move there
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# fetch git submodules
+echo "Updating git submodules..."
+git submodule update --init --recursive
+
+echo "Installing system packages..."
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends \
+        libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+else
+    echo "apt-get not found. Please install libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev manually."
+fi
+
+echo "Checking required tools..."
+if ! command -v just >/dev/null 2>&1; then
+    echo "Installing just..."
+    cargo install --locked just
+else
+    echo "just already installed"
+fi
+
+if ! command -v nickel >/dev/null 2>&1; then
+    echo "Installing nickel-lang-cli..."
+    cargo install --locked nickel-lang-cli
+else
+    echo "nickel already installed"
+fi
+
+# Add wasm target if necessary
+if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
+    echo "Adding wasm32-unknown-unknown target..."
+    rustup target add wasm32-unknown-unknown
+fi
+
+# Prefetch project dependencies
+echo "Fetching Cargo dependencies..."
+cargo fetch --locked --all-targets
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add a `scripts/dev_setup.sh` helper for initializing submodules and downloading dependencies
- mention the new script in the README
- include apt-based installation of required system libraries

## Testing
- `cargo test --locked` *(fails: linker out-of-memory)*

------
https://chatgpt.com/codex/tasks/task_e_683f5101553c83318a6c5f443eba1ee2