### PR TITLE
Fix dev_setup.sh noninteractive install

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -11,10 +11,11 @@ if ! command -v nix >/dev/null 2>&1; then
   . /etc/profile.d/nix.sh || true
 fi
 
-bash echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 
-nix profile install github:tweag/nickel || true
-nickel --version
+nix profile install --accept-flake-config github:tweag/nickel || true
+command -v nickel >/dev/null 2>&1 && nickel --version || true
 
 if ! command -v rustup >/dev/null 2>&1; then
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y build-essential git curl ca-certificates pkg-config libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  build-essential git curl ca-certificates pkg-config \
+  libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
 git submodule update --init --recursive || true
 
@@ -11,8 +13,10 @@ if ! command -v nix >/dev/null 2>&1; then
   . /etc/profile.d/nix.sh || true
 fi
 
-echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
-. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh || true
+mkdir -p /etc/nix
+grep -q '^experimental-features = nix-command flakes' /etc/nix/nix.conf 2>/dev/null || \
+  echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
 
 nix profile install --accept-flake-config github:tweag/nickel || true
 command -v nickel >/dev/null 2>&1 && nickel --version || true


### PR DESCRIPTION
## Summary
- fix malformed command writing nix config
- accept flake config for nix profile install
- skip nickel version check if nickel isn't installed

## Testing
- `./scripts/dev_setup.sh > /tmp/dev_setup.log` *(fails: interrupted by the user after lengthy nix build)*

------
https://chatgpt.com/codex/tasks/task_e_683f6933b71c833195064ca966f7280d